### PR TITLE
chore: exclude coverage file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ coverage
 !.changeset/
 pnpm-lock.yaml
 playgrounds/
+coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -22,3 +22,5 @@ components.d.ts
 auto-imports.d.ts
 
 playgrounds
+
+/coverage


### PR DESCRIPTION
执行 `pnpm eslint && pnpm format` 检查代码格式时，排除 `coverage` 文件